### PR TITLE
Relax dependency on base

### DIFF
--- a/haddock-cheatsheet.cabal
+++ b/haddock-cheatsheet.cabal
@@ -21,7 +21,7 @@ source-repository head
   location: https://github.com/daig/haddock-cheatsheet
 
 library
-  build-depends: base ^>= 4.12.0.0
+  build-depends: base
   exposed-modules: Doc.Haddock
   default-language: Haskell2010
   default-extensions: GADTs, PatternSynonyms


### PR DESCRIPTION
This package contains mostly documentation, it builds just fine with latest
base=4.18 and will continue to build in foreseeable future. This change makes
life of distributions easier, since they won't have to patch cabal file
themself.
